### PR TITLE
ghcr.io

### DIFF
--- a/.github/workflows/git-registry.yml
+++ b/.github/workflows/git-registry.yml
@@ -1,0 +1,24 @@
+name: Upload Image to Git Registry
+
+on: 
+    workflow_dispatch:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Login to Git Registry
+              run: echo "${{ secrets.GIT_REGISTRY_PASSWORD }}" | docker login -u "${{ secrets.GIT_REGISTRY_USERNAME }}" --password-stdin "${{ secrets.GIT_REGISTRY_URL }}"
+
+            - name: Build and Push Image
+              run: |
+                  docker build -t "${{ secrets.GIT_REGISTRY_URL }}/${{ secrets.GIT_REGISTRY_USERNAME }}/my-image" .
+                  docker push "${{ secrets.GIT_REGISTRY_URL }}/${{ secrets.GIT_REGISTRY_USERNAME }}/my-image"
+
+
+
+    


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of building and uploading a Docker image to a Git registry. The workflow is triggered manually via `workflow_dispatch`.

New GitHub Actions workflow:

* [`.github/workflows/git-registry.yml`](diffhunk://#diff-4adbf7cd717fcb014ba000a0ff25d5b76d647bdfd4c7891c0dcc61173d08ffb8R1-R24): Added a new workflow named "Upload Image to Git Registry" that includes steps for checking out the repository, logging in to the Git registry, and building and pushing a Docker image.